### PR TITLE
fix(types): support typescript 5.9

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -48,7 +48,7 @@ jobs:
       - run: pnpm test:deno && pnpm test:bun
 
   codeql-others:
-    name: codeql (devskim, snyk)
+    name: codeql (devskim)
     runs-on: ubuntu-latest
     permissions:
       actions: read
@@ -70,13 +70,3 @@ jobs:
         with:
           sarif_file: devskim-results.sarif
           category: devskim
-
-      - run: pnpm install -g snyk
-      - run: snyk auth --auth-type=token ${{ secrets.SNYK_TOKEN }}
-      - run: snyk monitor --all-projects
-      - run: snyk code test $(realpath src) --sarif > snyk-results.sarif
-      - run: node scripts/normalize-sarif.js snyk-results.sarif
-      - uses: github/codeql-action/upload-sarif@v3
-        with:
-          sarif_file: snyk-results.sarif
-          category: snyk

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -72,12 +72,9 @@ jobs:
           category: devskim
 
       - run: pnpm install -g snyk
+      - run: snyk auth --auth-type=token ${{ secrets.SNYK_TOKEN }}
       - run: snyk monitor --all-projects
-        env:
-          SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
       - run: snyk code test $(realpath src) --sarif > snyk-results.sarif
-        env:
-          SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
       - run: node scripts/normalize-sarif.js snyk-results.sarif
       - uses: github/codeql-action/upload-sarif@v3
         with:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -72,9 +72,12 @@ jobs:
           category: devskim
 
       - run: pnpm install -g snyk
-      - run: snyk auth ${{ secrets.SNYK_TOKEN }}
       - run: snyk monitor --all-projects
+        env:
+          SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
       - run: snyk code test $(realpath src) --sarif > snyk-results.sarif
+        env:
+          SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
       - run: node scripts/normalize-sarif.js snyk-results.sarif
       - uses: github/codeql-action/upload-sarif@v3
         with:

--- a/dist/index.d.cts
+++ b/dist/index.d.cts
@@ -1,13 +1,13 @@
 interface _Crypto {
     readonly subtle: _SubtleCrypto;
-    getRandomValues: (array: Uint8Array) => Uint8Array;
+    getRandomValues: (array: BufferSource) => BufferSource;
 }
 interface _SubtleCrypto {
-    decrypt: (algorithm: AesCbcParams | AesCtrParams | AesGcmParams | AlgorithmIdentifier | RsaOaepParams, key: CryptoKey, data: Uint8Array) => Promise<ArrayBuffer>;
+    decrypt: (algorithm: AesCbcParams | AesCtrParams | AesGcmParams | AlgorithmIdentifier | RsaOaepParams, key: CryptoKey, data: BufferSource) => Promise<ArrayBuffer>;
     deriveBits: (algorithm: AlgorithmIdentifier | EcdhKeyDeriveParams | HkdfParams | Pbkdf2Params, baseKey: CryptoKey, length: number) => Promise<ArrayBuffer>;
-    encrypt: (algorithm: AesCbcParams | AesCtrParams | AesGcmParams | AlgorithmIdentifier | RsaOaepParams, key: CryptoKey, data: Uint8Array) => Promise<ArrayBuffer>;
-    importKey: (format: Exclude<KeyFormat, 'jwk'>, keyData: ArrayBuffer | Uint8Array, algorithm: AesKeyAlgorithm | AlgorithmIdentifier | EcKeyImportParams | HmacImportParams | RsaHashedImportParams, extractable: boolean, keyUsages: KeyUsage[]) => Promise<CryptoKey>;
-    sign: (algorithm: AlgorithmIdentifier | EcdsaParams | RsaPssParams, key: CryptoKey, data: Uint8Array) => Promise<ArrayBuffer>;
+    encrypt: (algorithm: AesCbcParams | AesCtrParams | AesGcmParams | AlgorithmIdentifier | RsaOaepParams, key: CryptoKey, data: BufferSource) => Promise<ArrayBuffer>;
+    importKey: (format: Exclude<KeyFormat, 'jwk'>, keyData: BufferSource, algorithm: AesKeyAlgorithm | AlgorithmIdentifier | EcKeyImportParams | HmacImportParams | RsaHashedImportParams, extractable: boolean, keyUsages: KeyUsage[]) => Promise<CryptoKey>;
+    sign: (algorithm: AlgorithmIdentifier | EcdsaParams | RsaPssParams, key: CryptoKey, data: BufferSource) => Promise<ArrayBuffer>;
 }
 
 /**

--- a/dist/index.d.cts
+++ b/dist/index.d.cts
@@ -1,6 +1,6 @@
 interface _Crypto {
     readonly subtle: _SubtleCrypto;
-    getRandomValues: (array: BufferSource) => BufferSource;
+    getRandomValues: (array: ArrayBufferView) => ArrayBufferView;
 }
 interface _SubtleCrypto {
     decrypt: (algorithm: AesCbcParams | AesCtrParams | AesGcmParams | AlgorithmIdentifier | RsaOaepParams, key: CryptoKey, data: BufferSource) => Promise<ArrayBuffer>;

--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -1,13 +1,13 @@
 interface _Crypto {
     readonly subtle: _SubtleCrypto;
-    getRandomValues: (array: Uint8Array) => Uint8Array;
+    getRandomValues: (array: BufferSource) => BufferSource;
 }
 interface _SubtleCrypto {
-    decrypt: (algorithm: AesCbcParams | AesCtrParams | AesGcmParams | AlgorithmIdentifier | RsaOaepParams, key: CryptoKey, data: Uint8Array) => Promise<ArrayBuffer>;
+    decrypt: (algorithm: AesCbcParams | AesCtrParams | AesGcmParams | AlgorithmIdentifier | RsaOaepParams, key: CryptoKey, data: BufferSource) => Promise<ArrayBuffer>;
     deriveBits: (algorithm: AlgorithmIdentifier | EcdhKeyDeriveParams | HkdfParams | Pbkdf2Params, baseKey: CryptoKey, length: number) => Promise<ArrayBuffer>;
-    encrypt: (algorithm: AesCbcParams | AesCtrParams | AesGcmParams | AlgorithmIdentifier | RsaOaepParams, key: CryptoKey, data: Uint8Array) => Promise<ArrayBuffer>;
-    importKey: (format: Exclude<KeyFormat, 'jwk'>, keyData: ArrayBuffer | Uint8Array, algorithm: AesKeyAlgorithm | AlgorithmIdentifier | EcKeyImportParams | HmacImportParams | RsaHashedImportParams, extractable: boolean, keyUsages: KeyUsage[]) => Promise<CryptoKey>;
-    sign: (algorithm: AlgorithmIdentifier | EcdsaParams | RsaPssParams, key: CryptoKey, data: Uint8Array) => Promise<ArrayBuffer>;
+    encrypt: (algorithm: AesCbcParams | AesCtrParams | AesGcmParams | AlgorithmIdentifier | RsaOaepParams, key: CryptoKey, data: BufferSource) => Promise<ArrayBuffer>;
+    importKey: (format: Exclude<KeyFormat, 'jwk'>, keyData: BufferSource, algorithm: AesKeyAlgorithm | AlgorithmIdentifier | EcKeyImportParams | HmacImportParams | RsaHashedImportParams, extractable: boolean, keyUsages: KeyUsage[]) => Promise<CryptoKey>;
+    sign: (algorithm: AlgorithmIdentifier | EcdsaParams | RsaPssParams, key: CryptoKey, data: BufferSource) => Promise<ArrayBuffer>;
 }
 
 /**

--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -1,6 +1,6 @@
 interface _Crypto {
     readonly subtle: _SubtleCrypto;
-    getRandomValues: (array: BufferSource) => BufferSource;
+    getRandomValues: (array: ArrayBufferView) => ArrayBufferView;
 }
 interface _SubtleCrypto {
     decrypt: (algorithm: AesCbcParams | AesCtrParams | AesGcmParams | AlgorithmIdentifier | RsaOaepParams, key: CryptoKey, data: BufferSource) => Promise<ArrayBuffer>;

--- a/src/_crypto.ts
+++ b/src/_crypto.ts
@@ -1,6 +1,6 @@
 export interface _Crypto {
   readonly subtle: _SubtleCrypto
-  getRandomValues: (array: BufferSource) => BufferSource
+  getRandomValues: (array: ArrayBufferView) => ArrayBufferView
 }
 
 interface _SubtleCrypto {

--- a/src/_crypto.ts
+++ b/src/_crypto.ts
@@ -1,6 +1,6 @@
 export interface _Crypto {
   readonly subtle: _SubtleCrypto
-  getRandomValues: (array: Uint8Array) => Uint8Array
+  getRandomValues: (array: BufferSource) => BufferSource
 }
 
 interface _SubtleCrypto {

--- a/src/_crypto.ts
+++ b/src/_crypto.ts
@@ -7,7 +7,7 @@ interface _SubtleCrypto {
   decrypt: (
     algorithm: AesCbcParams | AesCtrParams | AesGcmParams | AlgorithmIdentifier | RsaOaepParams,
     key: CryptoKey,
-    data: Uint8Array
+    data: BufferSource
   ) => Promise<ArrayBuffer>
   deriveBits: (
     algorithm: AlgorithmIdentifier | EcdhKeyDeriveParams | HkdfParams | Pbkdf2Params,
@@ -17,11 +17,11 @@ interface _SubtleCrypto {
   encrypt: (
     algorithm: AesCbcParams | AesCtrParams | AesGcmParams | AlgorithmIdentifier | RsaOaepParams,
     key: CryptoKey,
-    data: Uint8Array
+    data: BufferSource
   ) => Promise<ArrayBuffer>
   importKey: (
     format: Exclude<KeyFormat, 'jwk'>,
-    keyData: ArrayBuffer | Uint8Array,
+    keyData: BufferSource,
     algorithm:
       | AesKeyAlgorithm
       | AlgorithmIdentifier
@@ -34,6 +34,6 @@ interface _SubtleCrypto {
   sign: (
     algorithm: AlgorithmIdentifier | EcdsaParams | RsaPssParams,
     key: CryptoKey,
-    data: Uint8Array
+    data: BufferSource
   ) => Promise<ArrayBuffer>
 }


### PR DESCRIPTION
https://www.typescriptlang.org/docs/handbook/release-notes/typescript-5-9.html#libdts-changes

I don't know if `ArrayBuffer` or `Uint8Array<ArrayBuffer>` would be more suitable here instead but lib.dom.d.ts and @types/node both use `BufferSource` so I just went with that.

Without this change we get

```
error TS2345: Argument of type 'Crypto' is not assignable to parameter of type '_Crypto'.
  The types of 'subtle.decrypt' are incompatible between these types.
    Type '(algorithm: AesCbcParams | AesCtrParams | AesGcmParams | AlgorithmIdentifier | RsaOaepParams, key: CryptoKey, data: BufferSource) => Promise<...>' is not assignable to type '(algorithm: AesCbcParams | AesCtrParams | AesGcmParams | AlgorithmIdentifier | RsaOaepParams, key: CryptoKey, data: Uint8Array<...>) => Promise<...>'.
      Types of parameters 'data' and 'data' are incompatible.
        Type 'Uint8Array<ArrayBufferLike>' is not assignable to type 'BufferSource'.
          Type 'Uint8Array<ArrayBufferLike>' is not assignable to type 'ArrayBufferView<ArrayBuffer>'.
            Types of property 'buffer' are incompatible.
              Type 'ArrayBufferLike' is not assignable to type 'ArrayBuffer'.
                Type 'SharedArrayBuffer' is not assignable to type 'ArrayBuffer'.
                  Types of property '[Symbol.toStringTag]' are incompatible.
                    Type '"SharedArrayBuffer"' is not assignable to type '"ArrayBuffer"'.

11     return Iron.seal(globalThis.crypto, data, secret, Iron.defaults)
                        ~~~~~~~~~~~~~~~~~

```